### PR TITLE
Converts schema of patternProperties using the convertProperties method

### DIFF
--- a/src/Converter/SchemaConverter.php
+++ b/src/Converter/SchemaConverter.php
@@ -86,6 +86,14 @@ class SchemaConverter
 
         if (isset($schema->{'x-patternProperties'}) && is_object($schema->{'x-patternProperties'}) && $options->supportPatternProperties) {
             $schema = self::convertPatternProperties($schema, $options->patternPropertiesHandler);
+
+            if (isset($schema->patternProperties) && is_object($schema->patternProperties)) {
+                $schema->patternProperties = self::convertProperties($schema->patternProperties, $options);
+
+                if (! (array) $schema->patternProperties) {
+                    unset($schema->patternProperties);
+                }
+            }
         }
 
         foreach ($notSupported as $prop) {

--- a/src/Converter/SchemaConverter.php
+++ b/src/Converter/SchemaConverter.php
@@ -89,10 +89,6 @@ class SchemaConverter
 
             if (isset($schema->patternProperties) && is_object($schema->patternProperties)) {
                 $schema->patternProperties = self::convertProperties($schema->patternProperties, $options);
-
-                if (! (array) $schema->patternProperties) {
-                    unset($schema->patternProperties);
-                }
             }
         }
 

--- a/tests/PatternPropertiesTest.php
+++ b/tests/PatternPropertiesTest.php
@@ -522,4 +522,39 @@ JSON
 
         self::assertEquals($expected, $result);
     }
+
+    public function testHandlingPatternPropertiesWithNullableTypes() : void
+    {
+        $schema = json_decode(<<<'JSON'
+            {
+                "type": "object",
+                "x-patternProperties": {
+                    "^[a-z]*$": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            }
+JSON
+        );
+
+        $expected = json_decode(<<<'JSON'
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": "object",
+                "patternProperties": {
+                    "^[a-z]*$": {
+                        "type": ["string", "null"]
+                    }
+                }
+            }
+JSON
+        );
+
+        $result = Convert::openapiSchemaToJsonSchema($schema, [
+            'supportPatternProperties' => true
+        ]);
+
+        self::assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
The contents of `patternProperties` need to also be converted to json-schema, just like OpenApi properties would.  This change calls `SchemaConverter:convertProperties` upon the results of `SchemaConverter:convertPatternProperties` to do so.