### PR TITLE
consistent casing for OpenApiSchemaToJsonSchema namespace

### DIFF
--- a/src/Converter/ParameterConverter.php
+++ b/src/Converter/ParameterConverter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace BenMorel\OpenApiSchemaToJsonSchema\Converter;
 
 use BenMorel\OpenApiSchemaToJsonSchema\Exception\InvalidInputException;
-use BenMorel\OpenapiSchemaToJsonSchema\Options;
+use BenMorel\OpenApiSchemaToJsonSchema\Options;
 
 use stdClass;
 

--- a/src/Converter/SchemaConverter.php
+++ b/src/Converter/SchemaConverter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace BenMorel\OpenApiSchemaToJsonSchema\Converter;
 
 use BenMorel\OpenApiSchemaToJsonSchema\Exception\InvalidTypeException;
-use BenMorel\OpenapiSchemaToJsonSchema\Options;
+use BenMorel\OpenApiSchemaToJsonSchema\Options;
 
 use stdClass;
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace BenMorel\OpenapiSchemaToJsonSchema;
+namespace BenMorel\OpenApiSchemaToJsonSchema;
 
 /**
  * The options passed to the converters.


### PR DESCRIPTION
Always use the same namespace casing as defined in `composer.json`

This fixes the error thrown by the [Symfony `DebugClassLoader`](https://github.com/symfony/error-handler/blame/5.x/DebugClassLoader.php) which checks casing:

> Case mismatch between loaded and declared class names: \"BenMorel\\OpenApiSchemaToJsonSchema\\Options\" vs \"BenMorel\\OpenapiSchemaToJsonSchema\\Options\".
