### PR TITLE
Recursive nullable objects

### DIFF
--- a/src/Converter/SchemaConverter.php
+++ b/src/Converter/SchemaConverter.php
@@ -44,7 +44,7 @@ class SchemaConverter
         if (isset($schema->nullable) && $schema->nullable === true) {
             foreach (['oneOf', 'anyOf', 'allOf'] as $xOf) {
                 if (isset($schema->{$xOf}) && is_array($schema->{$xOf})) {
-                    return self::convertNullableOneAnyAllOf($schema);
+                    return self::convertNullableOneAnyAllOf($schema, $options);
                 }
             }
         }
@@ -111,13 +111,15 @@ class SchemaConverter
 
     /**
      * @param object $schema
+     * @param Options $options
      *
      * @return object
      */
-    private static function convertNullableOneAnyAllOf(object $schema) : object
+    private static function convertNullableOneAnyAllOf(object $schema, Options $options) : object
     {
         $schemaCopy = clone $schema;
         unset($schemaCopy->nullable);
+        $schemaCopy = self::convertSchema($schemaCopy, $options);
 
         return (object) [
             'oneOf' => [

--- a/tests/NullableOneAnyAllOfTest.php
+++ b/tests/NullableOneAnyAllOfTest.php
@@ -92,6 +92,49 @@ JSON;
 JSON;
 
     /**
+     * A nullable one|any|allOf with an object that has a nullable property itself.
+     */
+    private const RECURSIVE = <<<'JSON'
+            {
+                "nullable": true,
+                "xxxOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "nullable": true
+                            }
+                        }
+                    }
+                ]
+            }
+JSON;
+
+    private const RECURSIVE_EXPECTED = <<<'JSON'
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "oneOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "xxxOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": ["integer", "null"]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+JSON;
+
+    /**
      * @dataProvider providerHandlesNullableOneAnyAllOf
      *
      * @param string $schema   The OpenAPI schema.
@@ -117,6 +160,11 @@ JSON;
             yield [
                 str_replace('xxxOf', $xOf, self::MULTIPLE),
                 str_replace('xxxOf', $xOf, self::MULTIPLE_EXPECTED)
+            ];
+
+            yield [
+                str_replace('xxxOf', $xOf, self::RECURSIVE),
+                str_replace('xxxOf', $xOf, self::RECURSIVE_EXPECTED)
             ];
         }
     }

--- a/tests/NullableTest.php
+++ b/tests/NullableTest.php
@@ -100,4 +100,37 @@ JSON
         $result = Convert::openapiSchemaToJsonSchema($schema);
         self::assertEquals($expected, $result);
     }
+
+    public function testHandlesNullableObjectsRecursively() : void
+    {
+        $schema = json_decode(<<<'JSON'
+            {
+                "nullable": true,
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "nullable": true,
+                        "type": "string"
+                    }
+                }
+            }
+JSON
+        );
+
+        $expected = json_decode(<<<'JSON'
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "type": ["object", "null"],
+                "properties": {
+                    "id": {
+                        "type": ["string", "null"]
+                    }
+                }
+            }
+JSON
+        );
+
+        $result = Convert::openapiSchemaToJsonSchema($schema);
+        self::assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
When an object was inside a nullable `one/any/allOf` struct, it was not recursively converted.

The schema rendered inside the newly `oneOf` struct also had to be converted.

Added a test for this case to check the bug, as well as an additional test to check regular nullable recursiveness, but this last one already succeeded.